### PR TITLE
fix: Use `username` setting to create the connection URL

### DIFF
--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -37,7 +37,7 @@ class OracleConnector(SQLConnector):
 
         connection_url = sqlalchemy.engine.url.URL.create(
             drivername="oracle+cx_oracle",
-            username=config["user"],
+            username=config["username"],
             password=config["password"],
             host=config["host"],
             port=config["port"],


### PR DESCRIPTION
- Slack: https://meltano.slack.com/archives/C069CPBCVPV/p1742431307447549
- Linen: https://discuss.meltano.com/t/27112244/dear-all-in-this-medium-article-i-put-together-my-experience#ceffb4cc-422c-4a72-8937-2a310b499475